### PR TITLE
fix: update ticker tape symbols

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -178,11 +178,14 @@ function TickerTape() {
     "https://s3.tradingview.com/external-embedding/embed-widget-ticker-tape.js",
     {
       symbols: [
-        { proName: "AMEX:UUP", title: "Dollar (UUP)" },
-        { proName: "AMEX:IEF", title: "US 7‑10Y (IEF)" },
-        { proName: "TVC:UKOIL", title: "Brent" },
+        { proName: "OANDA:XAUUSD", title: "XAU/USD" },
+        { proName: "COMEX:GC1!", title: "Gold Futures" },
+        { proName: "TVC:DXY", title: "DXY" },
+        { proName: "TVC:US10Y", title: "US 10Y" },
+        { proName: "TVC:US02Y", title: "US 2Y" },
         { proName: "TVC:USOIL", title: "WTI" },
-        { proName: "OANDA:XAUUSD", title: "XAUUSD" },
+        { proName: "CBOE:VIX", title: "VIX" },
+        { proName: "BITSTAMP:BTCUSD", title: "BTC/USD" },
       ],
       showSymbolLogo: true,
       isTransparent: true,


### PR DESCRIPTION
## Summary
- replace inaccessible IEF/UUP tickers with core market symbols (gold spot & futures, DXY, US yields, WTI, VIX, BTC)

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ce1c574832fac4a0ecc82fcc0e6